### PR TITLE
Fix comment for shading color

### DIFF
--- a/WordAI.VSTO/WordXml.cs
+++ b/WordAI.VSTO/WordXml.cs
@@ -361,7 +361,7 @@ namespace WordAI
                             segmentRange.Shading.BackgroundPatternColor = wdBackColor;
                     }
 
-                    // Apply Background (Shading) Color.
+                    // Apply Foreground (Shading) Color.
                     if (!string.IsNullOrEmpty(seg.Foreground))
                     {
                         WdColor wdBackColor = RGBStringToWdColor(seg.Foreground);


### PR DESCRIPTION
## Summary
- update comment about shading color in `WordXml.cs`

## Testing
- `dotnet build WordAI.VSTO/WordAI.VSTO.csproj -warnaserror` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840fce26a60832c81ee73364c216491