### PR TITLE
Add xUnit tests for PromptManager

### DIFF
--- a/WordAI.Tests/PromptManagerTests.cs
+++ b/WordAI.Tests/PromptManagerTests.cs
@@ -1,0 +1,54 @@
+using System;
+using Xunit;
+using WordAI; // namespace of PromptManager and PromptEntry
+
+namespace WordAI.Tests
+{
+    public class PromptManagerTests
+    {
+        [Fact]
+        public void SaveAndLoad_PreservesPromptEntries()
+        {
+            // Create unique temp home to isolate file path
+            string tempHome = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
+            System.IO.Directory.CreateDirectory(tempHome);
+            string originalHome = Environment.GetEnvironmentVariable("HOME");
+            Environment.SetEnvironmentVariable("HOME", tempHome);
+            try
+            {
+                // first manager
+                var manager = new PromptManager();
+                manager.Prompts.Clear();
+                var entry = new PromptEntry
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Label = "Test",
+                    Prompt = "Say hello",
+                    Model = "gpt",
+                    Context = ContextType.prefix.ToString(),
+                    Output = OutputType.comments.ToString(),
+                    Mode = ChunkingMode.ListAware
+                };
+                manager.Prompts.Add(entry);
+                manager.Save();
+
+                // new manager loads existing data
+                var manager2 = new PromptManager();
+                Assert.Single(manager2.Prompts);
+                var loaded = manager2.Prompts[0];
+                Assert.Equal(entry.Id, loaded.Id);
+                Assert.Equal(entry.Label, loaded.Label);
+                Assert.Equal(entry.Prompt, loaded.Prompt);
+                Assert.Equal(entry.Model, loaded.Model);
+                Assert.Equal(entry.Context, loaded.Context);
+                Assert.Equal(entry.Output, loaded.Output);
+                Assert.Equal(entry.Mode, loaded.Mode);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("HOME", originalHome);
+                System.IO.Directory.Delete(tempHome, true);
+            }
+        }
+    }
+}

--- a/WordAI.Tests/WordAI.Tests.csproj
+++ b/WordAI.Tests/WordAI.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\WordAI.VSTO\PromptManager.cs" Link="PromptManager.cs" />
+  </ItemGroup>
+</Project>

--- a/WordAI.VSTO/WordAI.sln
+++ b/WordAI.VSTO/WordAI.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.12.35728.132
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WordAI.VSTO", "WordAI.VSTO.csproj", "{7B212053-97FC-40F2-822B-6E03E110712D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WordAI.Tests", "WordAI.Tests\WordAI.Tests.csproj", "{56ED6733-D58B-427D-A58A-68DE421B554B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,9 +15,13 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7B212053-97FC-40F2-822B-6E03E110712D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7B212053-97FC-40F2-822B-6E03E110712D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7B212053-97FC-40F2-822B-6E03E110712D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7B212053-97FC-40F2-822B-6E03E110712D}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {7B212053-97FC-40F2-822B-6E03E110712D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {7B212053-97FC-40F2-822B-6E03E110712D}.Release|Any CPU.Build.0 = Release|Any CPU
+                {56ED6733-D58B-427D-A58A-68DE421B554B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {56ED6733-D58B-427D-A58A-68DE421B554B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {56ED6733-D58B-427D-A58A-68DE421B554B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {56ED6733-D58B-427D-A58A-68DE421B554B}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add a WordAI.Tests project with xUnit
- ensure prompts persist by saving and reloading using PromptManager
- link PromptManager.cs into test project
- update solution file to include the test project

## Testing
- `dotnet test WordAI.VSTO/WordAI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840fcf979b0832c87b399d3cf6614f2