### PR TITLE
Fix trimming of LLM responses

### DIFF
--- a/WordAI.VSTO/AssistantRibbon.cs
+++ b/WordAI.VSTO/AssistantRibbon.cs
@@ -773,7 +773,7 @@ You only provide the corrected text. You do not provide any additional comment.
                             aiResponseBuilder.Append(completionUpdate.ContentUpdate[0].Text);
                         }
 
-                        string aiResponse = aiResponseBuilder.ToString();
+                        string aiResponse = aiResponseBuilder.ToString().Trim();
 
                         bool prevTrackRevisionsState = doc.TrackRevisions;
                         if (trackedChanges)
@@ -1132,7 +1132,7 @@ Work on the following text (and only the following text):
                         progress("formatting response", 0.9f);
 
 
-                        string aiResponse = aiResponseBuilder.ToString();
+                        string aiResponse = aiResponseBuilder.ToString().Trim();
 
                         if (aiResponse.Trim().StartsWith("<think>")) // this is a thinking model
                         {


### PR DESCRIPTION
## Summary
- trim AI responses before applying tracked changes

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687532b0692c832c982d41332984f846