### PR TITLE
Improve prompt management tests and guidance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,3 +21,6 @@ jobs:
         working-directory: WordAI.VSTO
         shell: cmd
         run: "\"C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\MSBuild\\Current\\Bin\\MSBuild.exe\" WordAI.VSTO.csproj /p:Configuration=Release /p:TargetFrameworkVersion=v4.8 /p:SignManifests=false /p:GenerateManifests=false"
+
+      - name: Run unit tests
+        run: dotnet test WordAI.Tests/WordAI.Tests.csproj

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Guidance for Contributors
+
+- Use four-space indentation and LF line endings.
+- Run tests with `DOTNET_ROLL_FORWARD=Major dotnet test WordAI.Tests/WordAI.Tests.csproj` before committing.
+- The `WordAI.VSTO` project targets .NET Framework 4.8 and requires Visual Studio on Windows; avoid building it on Linux.
+- Update this file and the README when build or test instructions change.

--- a/README.md
+++ b/README.md
@@ -76,3 +76,13 @@ Here we compare a similar action performed with Microsoft Copilot and WordAI. No
 
 WordAI is definitely BETA software. I use it and "it works on my machine" - Install at your own risks, and reach out if you would like to collaborate for improvements !
 
+## Development
+
+The repository includes unit tests for the prompt management features. If your environment only has a newer .NET SDK installed, you can run the tests with:
+
+```bash
+DOTNET_ROLL_FORWARD=Major dotnet test WordAI.Tests/WordAI.Tests.csproj
+```
+
+Building the VSTO add-in itself requires Windows, Visual Studio and the .NET Framework 4.8 tooling.
+

--- a/WordAI.VSTO/PromptManager.cs
+++ b/WordAI.VSTO/PromptManager.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace WordAI
 {
@@ -11,17 +12,16 @@ namespace WordAI
         document = 3,
     }
 
-	public enum ChunkingMode
-	{
-		Paragraph,     // Default: one paragraph per chunk
-		ListAware,     // Group contiguous list items into a single chunk
-		WholeBlock,    // Process the entire selection as one chunk
-		Sentence,      // (Optional) Split by sentence boundaries (if you add NLP support)
-		Hybrid         // (Optional) Use heuristics based on size + structure
-	}
+    public enum ChunkingMode
+    {
+        Paragraph,     // Default: one paragraph per chunk
+        ListAware,     // Group contiguous list items into a single chunk
+        WholeBlock,    // Process the entire selection as one chunk
+        Sentence,      // (Optional) Split by sentence boundaries (if you add NLP support)
+        Hybrid         // (Optional) Use heuristics based on size + structure
+    }
 
-
-	public enum OutputType
+    public enum OutputType
     {
         text = 0,
         comments = 1,
@@ -36,8 +36,8 @@ namespace WordAI
         public string Model { get; set; }
         public string Context { get; set; }
         public string Output { get; set; }
-		public ChunkingMode Mode { get; set; }  // Enum: Paragraph, ListAware, WholeBlock
-	}
+        public ChunkingMode Mode { get; set; }  // Enum: Paragraph, ListAware, WholeBlock
+    }
 
     // A manager that loads and saves prompts from a JSON file.
     public class PromptManager
@@ -87,12 +87,7 @@ namespace WordAI
 
         internal PromptEntry Get(string guid)
         {
-            foreach (PromptEntry entry in Prompts)
-            {
-                if (entry.Id == guid)
-                    return entry;
-            }
-            return new PromptEntry();
+            return Prompts.FirstOrDefault(entry => entry.Id == guid) ?? new PromptEntry();
         }
     }
 }


### PR DESCRIPTION
## Summary
- tidy `PromptManager` enums and lookup logic
- add tests for defaults and retrieval
- document development workflow and run tests in CI
- add contributor guidelines and editor settings

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet test WordAI.Tests/WordAI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b5b398f888832c8f301c58ef7d765d