### PR TITLE
Use temporary certificate for ClickOnce manifests in CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,10 +22,12 @@ jobs:
         shell: pwsh
         run: |
           $cert = New-SelfSignedCertificate -Type CodeSigning -Subject "CN=WordAI" -CertStoreLocation Cert:\CurrentUser\My
-          $pwd = ConvertTo-SecureString -String 'password' -Force -AsPlainText
-          Export-PfxCertificate -Cert $cert -FilePath WordAI_TemporaryKey.pfx -Password $pwd
+          echo "CERT_THUMBPRINT=$($cert.Thumbprint)" >> $env:GITHUB_ENV
 
       - name: Build Project
         working-directory: WordAI.VSTO
-        shell: cmd
-        run: "\"C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\MSBuild\\Current\\Bin\\MSBuild.exe\" WordAI.VSTO.csproj /p:Configuration=Release /p:TargetFrameworkVersion=v4.8 /p:ManifestKeyFile=WordAI_TemporaryKey.pfx /p:PfxPassword=password"
+        shell: pwsh
+        run: |
+          $msbuild = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
+          & $msbuild WordAI.VSTO.csproj /p:Configuration=Release /p:TargetFrameworkVersion=v4.8 /p:ManifestCertificateThumbprint=$env:CERT_THUMBPRINT "/p:ManifestKeyFile="
+

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,15 @@ jobs:
         working-directory: WordAI.VSTO
         run: nuget restore WordAI.VSTO.csproj -SolutionDirectory .
 
+      - name: Create temporary signing certificate
+        working-directory: WordAI.VSTO
+        shell: pwsh
+        run: |
+          $cert = New-SelfSignedCertificate -Type CodeSigning -Subject "CN=WordAI" -CertStoreLocation Cert:\CurrentUser\My
+          $pwd = ConvertTo-SecureString -String 'password' -Force -AsPlainText
+          Export-PfxCertificate -Cert $cert -FilePath WordAI_TemporaryKey.pfx -Password $pwd
+
       - name: Build Project
         working-directory: WordAI.VSTO
         shell: cmd
-        run: "\"C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\MSBuild\\Current\\Bin\\MSBuild.exe\" WordAI.VSTO.csproj /p:Configuration=Release /p:TargetFrameworkVersion=v4.8 /p:SignManifests=false /p:GenerateManifests=false"
+        run: "\"C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\MSBuild\\Current\\Bin\\MSBuild.exe\" WordAI.VSTO.csproj /p:Configuration=Release /p:TargetFrameworkVersion=v4.8 /p:ManifestKeyFile=WordAI_TemporaryKey.pfx /p:PfxPassword=password"

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ Here we compare a similar action performed with Microsoft Copilot and WordAI. No
 
 # Continuous Integration
 
-The GitHub workflow builds the VSTO add-in using a self-signed certificate generated at build time. This certificate is used
-only to satisfy ClickOnce manifest signing requirements and is not intended for production use.
+The GitHub workflow builds the VSTO add-in using a self-signed certificate generated at build time. The certificate is placed in the Windows certificate store and referenced by its thumbprint during the build. It exists solely to satisfy ClickOnce manifest signing requirements and is not intended for production use.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Here we compare a similar action performed with Microsoft Copilot and WordAI. No
 
 ![assistants](doc/img/example-translate-with-style.gif)
 
+# Continuous Integration
+
+The GitHub workflow builds the VSTO add-in using a self-signed certificate generated at build time. This certificate is used
+only to satisfy ClickOnce manifest signing requirements and is not intended for production use.
+
 # Contributing
 
 WordAI is definitely BETA software. I use it and "it works on my machine" - Install at your own risks, and reach out if you would like to collaborate for improvements !


### PR DESCRIPTION
## Summary
- create a self-signed certificate during the workflow and use it to sign ClickOnce manifests
- document CI approach for manifest signing in the README

## Testing
- `dotnet test WordAI.Tests/WordAI.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b5b98b74f4832c9ae43fef724faf2a